### PR TITLE
Must escape + sign in regex 

### DIFF
--- a/bin/ocra
+++ b/bin/ocra
@@ -190,7 +190,7 @@ module Ocra
     # Directories anywhere
     (^|\/)(\.autotest|\.svn|\.cvs|\.git)(\/|$) |
     # Unlikely extensions
-    \.(rdoc|c|cpp|c++|cxx|h|hxx|hpp|obj|o|a)$/
+    \.(rdoc|c|cpp|c\+\+|cxx|h|hxx|hpp|obj|o|a)$/
   )}xi
   
   GEM_NON_FILE_RE = /(#{GEM_EXTRA_RE}|#{GEM_SCRIPT_RE})/


### PR DESCRIPTION
Commit c6a5e555d24aebbcbf37 introduced c++ in the list of extensions to ignore, the + signs should be escaped for the regex to be valid (Ruby 1.8.7 windows).
