### PR TITLE
Debugging bundler/Gemfile issues

### DIFF
--- a/bin/ocra
+++ b/bin/ocra
@@ -557,6 +557,14 @@ EOF
         Ocra.verbose_msg "From Gemfile, adding gem #{spec.full_name}"
         gems << [Pathname(spec.base_dir), spec.full_name]
       end
+
+      unless gems.any?{|dir, name| name =~ /^bundler-[.0-9]+/}
+        # Bundler itself wasn't added for some reason, let's put it in directly
+        Ocra.verbose_msg "From Gemfile, forcing inclusion of bundler gem itself"
+        bundler_spec = Gem.loaded_specs["bundler"]
+        bundler_spec or Ocra.fatal_error "Unable to locate bundler gem"
+        gems << [Pathname(bundler_spec.base_dir), bundler_spec.full_name]
+      end
     end
 
     if defined?(Gem)


### PR DESCRIPTION
Trying to figure out what's going on in some of the problems people are talking about on the mailing list, I noticed that both problems seem to be related to Bundler's gem not being included.

I am unable to reproduce this problem myself. However I try it, bundler is automatically included in the list of gems loaded from any Gemfile, even very simple Gemfiles with one gem, and even with the version of Bundler that the people on the mailing list are using.

But assuming that that's what is going wrong with these other systems, perhaps this patch will help. It looks through the gem list after a Gemfile has been scanned, and if bundler isn't already in that list, it adds it manually.
