### PR TITLE
Clear Bundler settings in ENV

### DIFF
--- a/bin/ocra
+++ b/bin/ocra
@@ -894,6 +894,8 @@ EOF
       sb.setenv('RUBYOPT', ENV['RUBYOPT'] || '')
       sb.setenv('RUBYLIB', load_path.map{|path| path.to_native}.uniq.join(';'))
       sb.setenv('GEM_PATH', (TEMPDIR_ROOT / GEMHOMEDIR).to_native)
+      sb.setenv('BUNDLE_GEMFILE', '')
+      sb.setenv('BUNDLE_BIN_PATH', '')
 
       # Add the opcode to launch the script
       extra_arg = Ocra.arg.map { |arg| ' "' + arg.gsub("\"","\\\"") + '"' }.join


### PR DESCRIPTION
Although RUBYLIB and RUBYOPTS are cleared by Ocra, if an Ocra-executable that uses Bundler is run from another instance of Ruby that is using Bundler, then it will think that it should use the calling instance's gemfile and will fail. To combat this, clearing the Bundler environment variables when starting the executable allows this to work.

```
# This will fail, since the ocra-app will try to use the Gemfile from the calling application.
require 'bundler/setup'
exec 'ocra_app_that_uses_bundler.exe'
```
