### PR TITLE
Bundler gems installed from sources other than rubygems were breaking ocra build

### DIFF
--- a/bin/ocra
+++ b/bin/ocra
@@ -83,6 +83,7 @@ module Ocra
     end
 
     def entries
+      @path.strip!
       Dir.entries(@path).map { |e| self / e }
     end
 
@@ -578,11 +579,18 @@ EOF
           end
         end
       end
-
+      
       gems = sort_uniq(gems)
       gem_files = []
+  
       gems.each do |gempath, fullgemname|
         gemspecpath = gempath / 'specifications' / "#{fullgemname}.gemspec"
+        if not File.exists? gemspecpath
+          gem_name = fullgemname.split('-')[0]
+          path = `bundle show #{gem_name}`
+          gemspecpath = Pathname("#{path.strip}/#{gem_name}.gemspec")
+        end
+
         @gemspecs << gemspecpath
         spec = Gem::Specification.load(gemspecpath)
 
@@ -623,9 +631,14 @@ EOF
           end
         end
 
+  
         Ocra.msg "Detected gem #{spec.full_name} (#{include.join(', ')})"
 
+
         gem_root = gempath / "gems" / spec.full_name
+        if not Dir.exists? gem_root
+          gem_root = Pathname(`bundle show #{spec.name}`)
+        end
         gem_root_files = nil
         files = []
 


### PR DESCRIPTION
Because of the way how gemspec files were calculated, ocra was breaking for gems that were installed via git or local path like this 

`gem 'spree', :git => 'git://github.com/spree/spree.git'`

Attached is a hacky patch to address such gems in the bundler file. 

Fixes the proper gemspec file and where the files need to be fetched from when.