### PR TITLE
Ignore "thread.rb" module

### DIFF
--- a/bin/ocra
+++ b/bin/ocra
@@ -177,7 +177,7 @@ module Ocra
 
   VERSION = "1.3.1"
 
-  IGNORE_MODULES = /^enumerator.so$/
+  IGNORE_MODULES = /^enumerator.so$|^thread.rb$/
 
   GEM_SCRIPT_RE = /\.rbw?$/
   GEM_EXTRA_RE = %r{(


### PR DESCRIPTION
The "thread.rb" module is picked up under Ruby 2.1 as a loaded feature.
Since it has no absolute path, ocra ends up trying to resolve it as a
user-supplied file, which fails.

This commit adds it to the IGNORE_MODULES regex so it is properly
filtered out.