### PR TITLE
Fixed ReadMe to be more readable in Markdown/Github

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -61,59 +61,59 @@ dependencies (gems and DLLs) into an executable named
 
 Ocra options:
 
---help             Display this information.
---quiet            Suppress output while building executable.
---verbose          Show extra output while building executable.
---version          Display version number and exit.
+    --help             Display this information.
+    --quiet            Suppress output while building executable.
+    --verbose          Show extra output while building executable.
+    --version          Display version number and exit.
 
 Packaging options:
 
---dll dllname      Include additional DLLs from the Ruby bindir.
---add-all-core     Add all core ruby libraries to the executable.
---gemfile <file>   Add all gems and dependencies listed in a Bundler Gemfile.
---no-enc           Exclude encoding support files
+    --dll dllname      Include additional DLLs from the Ruby bindir.
+    --add-all-core     Add all core ruby libraries to the executable.
+    --gemfile <file>   Add all gems and dependencies listed in a Bundler Gemfile.
+    --no-enc           Exclude encoding support files
 
 Gem content detection modes:
 
---gem-minimal[=gem1,..]  Include only loaded scripts
---gem-guess=[gem1,...]   Include loaded scripts & best guess (DEFAULT)
---gem-all[=gem1,..]      Include all scripts & files
---gem-full[=gem1,..]     Include EVERYTHING
---gem-spec[=gem1,..]     Include files in gemspec (Does not work with Rubygems 1.7+)
+    --gem-minimal[=gem1,..]  Include only loaded scripts
+    --gem-guess=[gem1,...]   Include loaded scripts & best guess (DEFAULT)
+    --gem-all[=gem1,..]      Include all scripts & files
+    --gem-full[=gem1,..]     Include EVERYTHING
+    --gem-spec[=gem1,..]     Include files in gemspec (Does not work with Rubygems 1.7+)
 
-  minimal: loaded scripts
-  guess: loaded scripts and other files
-  all: loaded scripts, other scripts, other files (except extras)
-  full: Everything found in the gem directory
+  minimal: loaded scripts  
+  guess: loaded scripts and other files  
+  all: loaded scripts, other scripts, other files (except extras)  
+  full: Everything found in the gem directory  
 
---[no-]gem-scripts[=..]  Other script files than those loaded
---[no-]gem-files[=..]    Other files (e.g. data files)
---[no-]gem-extras[=..]   Extra files (README, etc.)
+    --[no-]gem-scripts[=..]  Other script files than those loaded
+    --[no-]gem-files[=..]    Other files (e.g. data files)
+    --[no-]gem-extras[=..]   Extra files (README, etc.)
 
-  scripts: .rb/.rbw files
-  extras: C/C++ sources, object files, test, spec, README
-  files: all other files
+  scripts: .rb/.rbw files  
+  extras: C/C++ sources, object files, test, spec, README  
+  files: all other files  
 
 Auto-detection options:
 
---no-dep-run       Don't run script.rb to check for dependencies.
---no-autoload      Don't load/include script.rb's autoloads.
---no-autodll       Disable detection of runtime DLL dependencies.
+    --no-dep-run       Don't run script.rb to check for dependencies.
+   --no-autoload      Don't load/include script.rb's autoloads.
+    --no-autodll       Disable detection of runtime DLL dependencies.
 
 Output options:
 
---output <file>    Name the exe to generate. Defaults to ./<scriptname>.exe.
---no-lzma          Disable LZMA compression of the executable.
---innosetup <file> Use given Inno Setup script (.iss) to create an installer.
+    --output <file>    Name the exe to generate. Defaults to ./<scriptname>.exe.
+    --no-lzma          Disable LZMA compression of the executable.
+    --innosetup <file> Use given Inno Setup script (.iss) to create an installer.
 
 Executable options:
 
---windows          Force Windows application (rubyw.exe)
---console          Force console application (ruby.exe)
---chdir-first      When exe starts, change working directory to app dir.
---icon <ico>       Replace icon with a custom one.
---debug            Executable will be verbose.
---debug-extract    Executable will unpack to local dir and not delete after.
+    --windows          Force Windows application (rubyw.exe)  
+    --console          Force console application (ruby.exe)  
+    --chdir-first      When exe starts, change working directory to app dir.  
+    --icon <ico>       Replace icon with a custom one.  
+    --debug            Executable will be verbose.  
+    --debug-extract    Executable will unpack to local dir and not delete after.  
 
   
 === Compilation:


### PR DESCRIPTION
I was trying to read the readme on Github and the lists of options were not very readable.

I reformatted all option lists to code blocks by prefacing them with four spaces.  These should still be readable in rdoc format, just MORE readable in Github Markdown.