### PR TITLE
Do not try to add ignored Ruby modules when building Innosetup file.

### DIFF
--- a/bin/ocra
+++ b/bin/ocra
@@ -1069,7 +1069,7 @@ EOF
           @files.each do |tgt, src|
             src_escaped = src.to_s.gsub('"', '""')
             target_dir_escaped = Pathname.new(tgt).dirname.to_s.gsub('"', '""')
-            iss << "Source: \"#{src_escaped}\"; DestDir: \"{app}/#{target_dir_escaped}\"\n"
+            iss << "Source: \"#{src_escaped}\"; DestDir: \"{app}/#{target_dir_escaped}\"\n" unless src_escaped =~ IGNORE_MODULES
           end
           iss << "\n"
 


### PR DESCRIPTION
When creating Innosetup executable, enumerator.so and thread.rb files were tried to be included even though they don't exist. Those files are listed in IGNORE_MODULES and they are correctly handled during OcraBuilder.new phase. However, they were added from @files to the ocratemp.iss and read from there, obviously without success. This commit just excludes IGNORE_MODULES files from the ocratemp.iss.