### PR TITLE
bug fixing: extension.so and gen.build_complete

### DIFF
--- a/bin/ocra
+++ b/bin/ocra
@@ -655,6 +655,12 @@ EOF
         Ocra.msg "Detected gem #{spec.full_name} (#{include.join(', ')})"
 
         gem_root = Pathname(spec.gem_dir)
+        gem_extension = (gem_root / '..' / '..' / 'extensions').expand
+        if gem_extension.exist?
+          build_complete = gem_extension.find_all_files(/gem.build_complete/).select{|p| p.dirname.basename.to_s == spec.full_name}
+        else
+          build_complete = nil
+        end
         gem_root_files = nil
         files = []
 
@@ -673,6 +679,7 @@ EOF
           when :files
             gem_root_files ||= gem_root.find_all_files(//)
             files << gem_root_files.select { |path| path.relative_path_from(gem_root) !~ GEM_NON_FILE_RE }
+            files << build_complete if build_complete
           when :extra
             gem_root_files ||= gem_root.find_all_files(//)
             files << gem_root_files.select { |path| path.relative_path_from(gem_root) =~ GEM_EXTRA_RE }
@@ -1068,6 +1075,7 @@ EOF
           iss << "Source: \"#{path_escaped}\"; DestDir: \"{app}\"\n"
           @files.each do |tgt, src|
             src_escaped = src.to_s.gsub('"', '""')
+            next if src_escaped =~ IGNORE_MODULES
             target_dir_escaped = Pathname.new(tgt).dirname.to_s.gsub('"', '""')
             iss << "Source: \"#{src_escaped}\"; DestDir: \"{app}/#{target_dir_escaped}\"\n"
           end


### PR DESCRIPTION
Using ruby 2.1.6p336 and ocra-1.3.5 with inno setup option:
1) ocra add extension.so to the ocratemp.iss, but he file enumerator.so is not instaled by ruby 2.1.6 (not in my entire disk).  Otra defined  const IGNORE_MODULES already contains enumerador.so, but seems this constant is ignore when innosetup option is used.

2) I'm using psych-2.0.13, a gem with native extensions. Ocra detect and include it in the inno setup installer. When I run the installed project psych-2.0.13 it complaints about the gem native extension not builded. The problem is the file gem.build_complete is missing in extensions folder: ocra must add this file to ocratemp.iss if present when orca detect a gem.

This pull request fix both problems