### PR TITLE
Update to recent bundler

### DIFF
--- a/bin/ocra
+++ b/bin/ocra
@@ -563,7 +563,9 @@ EOF
       end
 
       ENV['BUNDLE_GEMFILE'] = Ocra.gemfile
-      Bundler.load.specs.each do |spec|
+      bundler_definition = Bundler::Definition.build(Bundler::SharedHelpers.default_gemfile, Bundler::SharedHelpers.default_lockfile, nil)
+
+      bundler_definition.specs_for([:default]).each do |spec|
         Ocra.verbose_msg "From Gemfile, adding gem #{spec.full_name}"
         gems[spec.name] ||= spec
       end
@@ -579,7 +581,7 @@ EOF
 
     if defined?(Gem)
       # Include Gems that are loaded
-      Gem.loaded_specs.each { |gemname, spec| gems[gemname] ||= spec }
+      Gem.loaded_specs.each { |gemname, spec| gems[gemname] ||= spec } unless Ocra.gemfile
       # Fall back to gem detection (loaded_specs are not population on
       # all Ruby versions)
       features.each do |feature|


### PR DESCRIPTION
The latest bundler doesn't reload the environment when load.specs is called (it's memoized), so the gemfile option is not respected.

Update to recent bundler, and make it possible to use the same gemfile for the complete project and the specific ocra executable.

You can now refer to a gemfile that is structured with groups and only include the gems that are relevant (in the below case ‘tiny_tds’)

source 'https://rubygems.org'
group :development do
  gem 'pry'
  gem ‘ocra’
end
gem 'tiny_tds'

I also changed that including the gemfile would not check the loaded gems, as in my usecase this would include additional gems I don't use in the executable (for example ocra itself).
