### PR TITLE
Fixed stub emebedding in ocrasa.rb

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -46,24 +46,20 @@ file 'bin/ocrasa.rb' => [ 'bin/ocra', 'share/ocra/stub.exe', 'share/ocra/stubw.e
     f.puts "__END__"
 
     stub = File.open("share/ocra/stub.exe", "rb") {|g| g.read}
-    stub64 = [stub].pack("m")
-    f.puts stub64.size
+    stub64 = [stub].pack("m0")
     f.puts stub64
 
-    stub = File.open("share/ocra/stubw.exe", "rb") {|g| g.read}
-    stub64 = [stub].pack("m")
-    f.puts stub64.size
-    f.puts stub64
+    stubw = File.open("share/ocra/stubw.exe", "rb") {|g| g.read}
+    stubw64 = [stubw].pack("m0")
+    f.puts stubw64
 
     lzma = File.open("share/ocra/lzma.exe", "rb") {|g| g.read}
-    lzma64 = [lzma].pack("m")
-    f.puts lzma64.size
+    lzma64 = [lzma].pack("m0")
     f.puts lzma64
 
-    lzma = File.open("share/ocra/edicon.exe", "rb") {|g| g.read}
-    lzma64 = [lzma].pack("m")
-    f.puts lzma64.size
-    f.puts lzma64
+    edicon = File.open("share/ocra/edicon.exe", "rb") {|g| g.read}
+    edicon64 = [edicon].pack("m0")
+    f.puts edicon64
   end
 end
 

--- a/bin/ocra
+++ b/bin/ocra
@@ -260,7 +260,7 @@ module Ocra
 
   # Returns a binary blob store embedded in the current Ruby script.
   def Ocra.get_next_embedded_image
-    DATA.read(DATA.readline.to_i).unpack("m")[0]
+    DATA.readline.chomp.unpack("m0")[0]
   end
 
   def Ocra.save_environment


### PR DESCRIPTION
I don't know fro what reason, but the Byte sizes where incorrect, resulting in false stubs.
The pack method has been changed to `m0`, resulting in one-liner stubs, which are read with `readline`.
