### PR TITLE
Fix: abort when using RubyInstaller 2.4.x

### DIFF
--- a/bin/ocra
+++ b/bin/ocra
@@ -850,6 +850,9 @@ EOF
     # Detect additional DLLs
     dlls = Ocra.autodll ? LibraryDetector.detect_dlls : []
 
+    # Detect external manifests
+    manifests = Host.exec_prefix.find_all_files(/\.manifest$/)
+
     executable = nil
     if Ocra.output_override
       executable = Ocra.output_override
@@ -909,6 +912,13 @@ EOF
           target = BINDIR / File.basename(dll)
         end
         sb.createfile(dll, target)
+      end
+
+      # Add external manifest files
+      manifests.each do |manifest|
+        Ocra.msg "Adding external manifest #{manifest}"
+        target = manifest.relative_path_from(Host.exec_prefix)
+        sb.createfile(manifest, target)
       end
 
       # Add extra DLLs specified on the command line


### PR DESCRIPTION
# Issue
In use [RubyInstaller](https://rubyinstaller.org/) 2.4.x, it abort with 14001 error (side-by-side configuration is incorrect) when attempt to run. 

It was caused by missing external-manifest file. (`bin/ruby_builtin_dlls/ruby_builtin_dlls.manifest`) 

# Solution 
Export with external-manifest file to exe, if it is contained under installed Ruby dir (`Host.exec_prefix`).